### PR TITLE
Add node service to lando-lagoon

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ description: The best local development option for Lagoon a Docker Build and Dep
 
 This is currently an _beta_ level integration that has the following _serious caveats_:
 
-* This _does not_ support Lagoon's `node`, `python` or `mongodb` containers yet
+* This _does not_ support Lagoon's `python` or `mongodb` containers yet
 * It's not yet clear how much customization to your project is currently supported
 
 However, if you'd like to try it out and give your feedback on what worked and what didn't then please continue.

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -20,6 +20,14 @@ const getOtherServingContainers = services => _(services)
   .value();
 
 /*
+ * Helper to find containers that serve
+ */
+const getNodeContainers = services => _(services)
+  .filter(service => service.type === 'lagoon-node')
+  .map('name')
+  .value();
+
+/*
  * Helper to map parsed platform config into related Lando things
  */
 exports.getLandoProxyRoutes = (services, domain, proxy = {}) => {
@@ -39,6 +47,14 @@ exports.getLandoProxyRoutes = (services, domain, proxy = {}) => {
   if (!_.isEmpty(otherServingContainers)) {
     _.forEach(otherServingContainers, service => {
       proxy[service] = [`${service}.${domain}:8080`];
+    });
+  }
+
+  const nodeContainers = nginxServers.concat(getNodeContainers(services));
+  // If we have other serving containers then lets also set up a proxies for those
+  if (!_.isEmpty(nodeContainers)) {
+    _.forEach(nodeContainers, service => {
+      proxy[service] = [`${service}.${domain}:3000`];
     });
   }
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -17,6 +17,7 @@ const getLandoServiceType = type => {
     case 'elasticsearch': return 'lagoon-elasticsearch';
     case 'nginx': return 'lagoon-nginx';
     case 'nginx-drupal': return 'lagoon-nginx';
+    case 'node': return 'lagoon-node';
     case 'none': return 'lagoon-none';
     case 'mariadb': return 'lagoon-mariadb';
     case 'mariadb-drupal': return 'lagoon-mariadb';

--- a/services/lagoon-node/builder.js
+++ b/services/lagoon-node/builder.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Modules
+const _ = require('lodash');
+
+// Builder
+module.exports = {
+  name: 'lagoon-node',
+  config: {
+    version: 'custom',
+    confSrc: __dirname,
+    command: '/sbin/tini -- /lagoon/entrypoints.sh yarn run start',
+    moreHttpPorts: ['3000'],
+    ports: ['3000'],
+  },
+  parent: '_lagoon',
+  builder: (parent, config) => class LandoLagoonNode extends parent {
+    constructor(id, options = {}, factory) {
+      options = _.merge({}, config, options);
+
+      // Build the node
+      const node = {ports: options.ports, command: options.command};
+
+      // Add in the php service and push downstream
+      super(id, options, {services: _.set({}, options.name, node)});
+    };
+  },
+};


### PR DESCRIPTION
This PR is to add a Node service to the Lagoon integration.

It is still marked as draft because the `otherServingContainers` func is hardcoded to port 8080 (which works for Varnish, but not Node (3000) or Python (8800) - so that routine will need modifying to support multiple proxy ports.  To get around this, I've created a standalone func for Node. In the medium-term, Lagoon will be making these ports configurable, so Lando will need a way to be told what port to use per service via the docker-compose.yaml

I also _think_ I've managed to set my local dev up properly to work on this as a plugin/integration, but :shrug:  
