### PR TITLE
use correct uselagoon/lagoon-cli image

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,7 +184,7 @@ lando yarn              Runs yarn commands
 
 Note that you can define your own commands by using out [tooling framework](https://docs.lando.dev/config/tooling.md). Also check out the guides for the powerful [DB Export](https://docs.lando.dev/guides/db-export.md) and [DB Import](https://docs.lando.dev/guides/db-import.md) commands.
 
-Also, check out the [Lagoon CLI Docs](https://amazeeio.github.io/lagoon-cli/commands/lagoon/) for more information on using `lando lagoon`.
+Also, check out the [Lagoon CLI Docs](https://uselagoon.github.io/lagoon-cli/commands/lagoon/) for more information on using `lando lagoon`.
 
 ### Mailhog
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -101,7 +101,7 @@ exports.getLandoAuxServices = (services = {}, config) => {
   services.lagooncli = {
     type: 'compose',
     services: {
-      image: 'amazeeio/lagoon-cli',
+      image: 'uselagoon/lagoon-cli',
       command: 'tail -f /dev/null',
       volumes: [
         `${config.home}:/root`,


### PR DESCRIPTION
We've moved the lagoon-cli image into the uselagoon namespace, this PR makes sure to pull that version (it's also M1 compatible)