### PR TITLE
fix: strip additional_contexts and resolve relative build contexts

### DIFF
--- a/builders/_lagoon.js
+++ b/builders/_lagoon.js
@@ -20,8 +20,11 @@ module.exports = {
       const hostnames = _.get(options, '_app.lagoon.containers', []);
 
       // Normalize the dockerfile situation
-      // We need to do this again since this isnt technically an override
-      if (_.has(lagoon, 'build.context')) lagoon.build.context = path.join(options.root);
+      // Resolve build context relative to the project root so non-root contexts
+      // (eg context: frontend) work correctly instead of always forcing root
+      if (_.has(lagoon, 'build.context')) {
+        lagoon.build.context = path.resolve(options.root, lagoon.build.context);
+      }
 
       // Handle portfoward in the usual way
       if (options.portforward) {

--- a/examples/drupal9-base/README.md
+++ b/examples/drupal9-base/README.md
@@ -48,7 +48,8 @@ lando ssh -s nginx -c "test -f /app/web/index.php"
 lando ssh -s php -c "test -f /app/web/index.php"
 
 # Should not have additional_contexts in the generated compose files
-cat ~/.lando/compose/drupalbase-* 2>/dev/null | grep -c "additional_contexts" | grep 0
+cd drupal
+cat ~/.lando/compose/drupalbase-* 2>/dev/null | grep "additional_contexts" && exit 1 || true
 
 # Should ssh against the cli container by default
 cd drupal

--- a/examples/drupal9-base/README.md
+++ b/examples/drupal9-base/README.md
@@ -41,6 +41,15 @@ docker ps --filter label=com.docker.compose.project | grep Up | grep drupalbase_
 docker ps --filter label=com.docker.compose.project | grep Up | grep drupalbase_php_1
 docker ps --filter label=com.docker.compose.project | grep Up | grep drupalbase_cli_1
 
+# Should have built nginx and php from the cli image via CLI_IMAGE build arg
+cd drupal
+lando ssh -s cli -c "test -f /app/web/index.php"
+lando ssh -s nginx -c "test -f /app/web/index.php"
+lando ssh -s php -c "test -f /app/web/index.php"
+
+# Should not have additional_contexts in the generated compose files
+cat ~/.lando/compose/drupalbase-* 2>/dev/null | grep -c "additional_contexts" | grep 0
+
 # Should ssh against the cli container by default
 cd drupal
 lando ssh -c "env | grep LAGOON=" | grep cli-drupal

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,11 +44,20 @@ exports.loadConfigFiles = baseDir => {
  */
 exports.parseServices = (services, recipeConfig) => _(services)
   // Remove unneeded things from the docker config and determine the type of the service
-  .map((config, name) => _.merge({}, {
-    name,
-    type: getLabel(config.labels),
-    compose: _.omit(config, ['volumes', 'volumes_from', 'networks', 'user']),
-    config: recipeConfig,
-  }))
+  .map((config, name) => {
+    // Strip additional_contexts from build config since Lando splits services
+    // into separate compose files and service: refs cant resolve across them
+    if (_.has(config, 'build.additional_contexts')) {
+      config = _.cloneDeep(config);
+      delete config.build.additional_contexts;
+    }
+
+    return _.merge({}, {
+      name,
+      type: getLabel(config.labels),
+      compose: _.omit(config, ['volumes', 'volumes_from', 'networks', 'user']),
+      config: recipeConfig,
+    });
+  })
   // Return
   .value();


### PR DESCRIPTION
## Problem

Two related build issues with the Lagoon plugin:

1. **`additional_contexts` with `service:` references fail** — Upstream lagoon-examples/drupal-base [added `additional_contexts`](https://github.com/lagoon-examples/drupal-base/commit/7e5001f5) in Aug 2025 to enforce BuildKit build ordering. Lando splits services into separate compose files, so Docker can't resolve `service:cli` across files and treats it as a filesystem path (`~/.lando/compose/drupalbase/service:cli`), causing all leia-tests to fail.

2. **`build.context` always forced to project root** — `_lagoon.js` rewrites `build.context` to `path.join(options.root)` regardless of the original value, breaking monorepo setups where services use non-root contexts (e.g. `context: frontend`).

## Fix

- **Strip `build.additional_contexts`** in `lib/config.js` during service parsing. The `CLI_IMAGE` build arg already handles cross-service image references (`ARG CLI_IMAGE` → `FROM ${CLI_IMAGE} AS cli`), making `additional_contexts` redundant for local dev.

- **Use `path.resolve`** instead of `path.join` in `_lagoon.js` so relative build contexts resolve correctly against the project root. `context: .` still resolves to root (no regression), but `context: frontend` now correctly resolves to `<root>/frontend`.

## Testing

- Unit tests pass
- The leia-test failures in CI (drupal9-base, all-services, proxy-tests) should be resolved by this fix since the upstream drupal-base example now uses `additional_contexts`

Fixes #7
Fixes #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lagoon service build configuration, which can affect how images are built and may break projects relying on current (incorrect) context rewriting or on `additional_contexts` behavior. Scope is limited to local compose/service parsing and build context normalization (no auth/data handling).
> 
> **Overview**
> Fixes Lagoon build compatibility in two places.
> 
> `builders/_lagoon.js` now resolves `build.context` relative to the project root (instead of forcing root), enabling non-root build contexts in monorepos. `lib/config.js` strips `build.additional_contexts` during service parsing to avoid Docker `service:` context references that can’t resolve when Lando splits services into separate compose files.
> 
> Updates the Drupal 9 base example README with verification steps to confirm images build via the shared CLI image and that generated compose files do not contain `additional_contexts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c609d4e29b502327fdac47996411736d78f1c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->